### PR TITLE
hotfix: prevent crash if sdk library is not loaded

### DIFF
--- a/src/js/sdk.js
+++ b/src/js/sdk.js
@@ -479,7 +479,7 @@ class SDK {
 	 * @returns {Promise}
 	 */
 	checkPermission(permission) {
-		return this.sdk.permissions.check({ permission });
+		return this.sdk?.permissions.check({ permission });
 	}
 
 	/**


### PR DESCRIPTION
hotfix: prevent crash if sdk library is not loaded